### PR TITLE
docs/basics/qsql.md: Update broken hyperlink

### DIFF
--- a/docs/basics/qsql.md
+++ b/docs/basics/qsql.md
@@ -38,7 +38,7 @@ A template is evaluated in the following order.
 <div markdown="1" class="typewriter">
 [From phrase](#from-phrase)        _t~exp~_
 [Where phrase](#where-phrase)       _p~w~_
-[By phrase](#by-phrase)          _p~b~_
+[By phrase](../ref/select.md#by-phrase)          _p~b~_
 [Select phrase](../ref/select.md#select-phrase)      _p~s~_
 [Limit expression](../ref/select.md#limit-expression)   _L~exp~_
 </div>


### PR DESCRIPTION
The hyperlink for the "By phrase" linked the a variable on the current page (which does not exist). I updated it like the select phrase to point to the reference itself.